### PR TITLE
모듈화를 위해 SharedPath를 정의하고 이것을 사용 가능하도록 StackState<>의 타입을 프로토콜로 추상화 했지만 기능하지 않습니다.

### DIFF
--- a/Gusto-iOS/Feature/AppFeature/SharedPathModule.swift
+++ b/Gusto-iOS/Feature/AppFeature/SharedPathModule.swift
@@ -1,0 +1,88 @@
+import ComposableArchitecture
+import SwiftUI
+
+//MARK: - App모듈
+//import SomeTab
+//import SomeTab2 ...
+@Reducer
+struct SharedPath {
+  public enum State: TabState {
+    case share1(SharedFeature.State)
+  }
+  public enum Action: TabAction {
+    case share1(SharedFeature.Action)
+  }
+  public var body: some ReducerOf<Self> {
+    Scope(state: \.share1, action: \.share1) {
+      SharedFeature()
+    }
+  }
+}
+
+@Reducer
+struct AppPathReducer {
+  struct State {
+    var tab1: SomeTab.State = .init()
+  }
+  enum Action {
+    case tab1(SomeTab.Action)
+  }
+  var body: some ReducerOf<Self> {
+    Scope(state: \.tab1, action: \.tab1) {
+      SomeTab()
+    }
+    Reduce { state, action in
+      switch action {
+      case .tab1(.appends(let tabState)):
+        state.tab1.paths.append(tabState)
+        return .none
+      default:
+        return .none
+      }
+    }
+  }
+}
+
+
+#Preview {
+  SomeTabView2(store: Store(initialState: SomeTab.State(), reducer: {
+    SomeTab()
+  }))
+}
+
+struct SharedPathRouter {
+  struct SharedState: TabState {
+    var state: SharedPath.State
+  }
+  enum SharedAction: TabAction {
+    case action(SharedPath.Action)
+  }
+  
+  func wrapState(_ state: SharedPath.State) -> SharedState {
+    SharedState(state: state)
+  }
+  func wrapAction(_ action: SharedPath.Action) -> SharedAction {
+    .action(action)
+  }
+  
+  @MainActor @ViewBuilder
+  func destination(store: Store<SharedState, SharedAction>) -> some View {
+    SwitchStore(store) { state in
+      CaseLet(\SharedPath.State.share1, action: SharedPath.Action.share1) { store in
+        SharedView(store: store)
+      }
+    }
+  }
+}
+extension SharedPathRouter: DependencyKey {
+  static let liveValue: SharedPathRouter = {
+    SharedPathRouter()
+  }()
+}
+
+extension DependencyValues {
+  var router: SharedPathRouter {
+    get {self[SharedPathRouter.self]}
+    set {self[SharedPathRouter.self] = newValue}
+  }
+}

--- a/Gusto-iOS/Feature/AppFeature/TMPSharedPathModule.swift
+++ b/Gusto-iOS/Feature/AppFeature/TMPSharedPathModule.swift
@@ -1,0 +1,137 @@
+import ComposableArchitecture
+import SwiftUI
+import Foundation
+
+//MARK: - 탭 모듈 레이어
+protocol TabState {}
+protocol TabAction {}
+
+
+@Reducer
+struct SomeTab {
+  @ObservableState
+  struct State {
+    var paths = StackState<any TabState>()
+  }
+  enum Action {
+    case paths(StackAction<any TabState, any TabAction>)
+    case appends(any TabState)
+  }
+  var body: some ReducerOf<Self> {
+    Reduce { state, action in
+      switch action {
+      case .appends(let a):
+        state.paths.append(a)
+        return .none
+      default:
+        return .none
+      }
+    }
+  }
+}
+
+@Reducer
+internal struct SomeTabPaths {
+  @ObservableState
+  enum State: TabState {
+    case one(isolFeature.State)
+    case two(isolFeature.State)
+    case shared(TabState)
+  }
+  enum Action: TabAction {
+    case one(isolFeature.Action)
+    case two(isolFeature.Action)
+    case shared(TabAction)
+  }
+  var body: some ReducerOf<Self> {
+    Scope(state: \.one, action: \.one) {
+      isolFeature()
+    }
+    Scope(state: \.two, action: \.two) {
+      isolFeature()
+    }
+  }
+}
+
+@Reducer
+public struct SharedFeature {
+  public struct State {}
+  public enum Action {
+    case buttonTapped
+  }
+  public var body: some ReducerOf<Self> {
+    Reduce { state, action in
+      switch action {
+      case .buttonTapped:
+        print("SharedButton Tapped")
+        return .none
+      }
+    }
+  }
+}
+struct SharedView: View {
+  let store: StoreOf<SharedFeature>
+  
+  var body: some View {
+    Button("Shared") {
+      store.send(.buttonTapped)
+    }
+  }
+}
+@Reducer
+struct isolFeature {
+  @ObservableState
+  struct State {
+    var txt: String
+  }
+  enum Action {}
+  var body: some ReducerOf<Self> {
+    Reduce { state, action in
+      switch action {}
+    }
+  }
+}
+struct isolView: View {
+  let store: StoreOf<isolFeature>
+  
+  var body: some View {
+    Text(store.txt)
+  }
+}
+struct SomeTabView2: View {
+  @Bindable var store: StoreOf<SomeTab>
+  @Dependency(\.router) var sharedPathRouter
+  var body: some View {
+    NavigationStackStore(store.scope(state: \.paths, action: \.paths)) {
+      Button("shared") {
+//        store.send(.appends(SomeTabPaths.State.shared(<#T##any TabState#>)))
+//        store.send(.appends(SomeTabPaths.State.shared(store.state.sharedPath.State.share1(SharedFeature.State()))))
+      }
+      Button("one") {
+        let oneState = SomeTabPaths.State.one(.init(txt: "one"))
+        store.send(.appends(oneState))
+        print("Button one tapped, appending: \(oneState)")
+      }
+    } destination: { store in
+      let _ = print("destination: \(String(describing: type(of: store)))")
+      switch store {
+      //!!!: 이곳에서 적절한 타입과 매칭이 실패
+      default:
+        EmptyView()
+      }
+    }
+  }
+}
+
+#Preview {
+  SomeTabView2(store: Store(initialState: SomeTab.State(), reducer: {
+    SomeTab()
+  }))
+}
+
+enum small {
+  case one, two, three
+  
+}
+
+


### PR DESCRIPTION
⚓ Related Issue

[탭바, 네비게이션](https://www.notion.so/28b7bd4828218070891fd5153e6325fd?source=copy_link)


🥥 Contents

모듈화에 맞게 네비게이션을 수정중입니다

📸 Screenshot


Other information 🔥

아무래도 StackState<>의 제네릭타입을 콘크리트 타입으로 하는 게 이유가 있어보입니다.

Tab1의 StackState는 StateState<Tab1.Path>이고
Tab2는 StateState<Tab2.Path>일 것입니다.
타입 불일치의 문제로 Tab1의 StackState에 Tab2.Path를 추가할 수가 없습니다.
그래서 모든 탭에서 StackState를<any 프로토콜>로 추상화하고 진행했는데, destination에서 적절한 store로의 타입 매칭이 실패합니다.

이러면 문제가 SharedPath를 하나 만들어서 공유되는 화면을 정의한다고 해도
각 탭의 StackState에 타입이 맞지 않아 넣어줄 수가 없습니다.

```
enum Tab1Path {
//...탭1의 화면들...
  case shared(SharedPath)
```

이 형태는 작동하지만, 이러면 모듈화가 깨집니다. 각 탭이 SharedPath가 있는 모듈을 참조해야해요