### PR TITLE
[fix] 네트워크 request에서 void타입을 리턴하는 메서드를 수정했습니다

### DIFF
--- a/GustoNetwork/Sources/Network/NetworkClient.swift
+++ b/GustoNetwork/Sources/Network/NetworkClient.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public protocol NetworkClient: Sendable {
-  func request<T>(_ request: Requestable) async throws -> T
+  func request<T: Decodable>(_ request: Requestable) async throws -> T
   var session: URLSession { get }
 }
 
@@ -13,5 +13,10 @@ extension NetworkClient {
     guard (200..<300) ~= httpResponse.statusCode else {
       throw NetworkError.responseError(statusCode: httpResponse.statusCode)
     }
+  }
+  public func request(_ request: Requestable) async throws -> Void {
+    let request = try request.makeRequest()
+    let (_, response) = try await session.data(for: request)
+    try self.validate(response)
   }
 }

--- a/GustoNetwork/Sources/Network/NetworkProtocolImplement.swift
+++ b/GustoNetwork/Sources/Network/NetworkProtocolImplement.swift
@@ -7,12 +7,6 @@ public final class NetworkProtocolImpl: NetworkClient {
     self.session = session
   }
   
-  public func request<T>(_ request: Requestable) async throws -> T {
-    let request = try request.makeRequest()
-    let (_, response) = try await session.data(for: request)
-    try validate(response)
-    return () as! T
-  }
   public func request<T>(_ request: Requestable) async throws -> T where T: Decodable {
     let request = try request.makeRequest()
     let (data, response) = try await session.data(for: request)

--- a/GustoNetwork/Sources/Network/RequestableProtocol.swift
+++ b/GustoNetwork/Sources/Network/RequestableProtocol.swift
@@ -25,7 +25,7 @@ extension Requestable {
     guard let url = URL(string: baseURL + self.path) else {
       throw NetworkError.invalidURL
     }
-    var urlRequest = URLRequest(url: URL(string: baseURL + self.path)!)
+    var urlRequest = URLRequest(url: url)
     urlRequest.httpMethod = self.method.rawValue
     self.headers?.forEach { urlRequest.addValue($1, forHTTPHeaderField: $0) }
     


### PR DESCRIPTION
<!--
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
[네트워크 수정](https://www.notion.so/request-2d67bd48282180f3ad68c4fcb0206e57?source=copy_link)

<br>

### 🥥 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

NetworkClient 프로토콜을 수정해서
```
func request<T>(_ request: Requestable) async throws -> T
```
에서 다음으로 변경했습니다.
```
func request<T: Decodable>(_ request: Requestable) async throws -> T
```
Void타입을 리턴하는 메서드는 프로토콜의 extension에 기본구현 메서드로 빼냈습니다.
```
  public func request(_ request: Requestable) async throws -> Void {
    let request = try request.makeRequest()
    let (_, response) = try await session.data(for: request)
    try self.validate(response)
  }
```

<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->

<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->

Void의 경우만 강제 형변환을 시켰었는데, 생각한 대로 안 되는군요

<br>
