### PR TITLE
[chore] review 도메인 endpoint 분리

### DIFF
--- a/GustoNetwork/Package.swift
+++ b/GustoNetwork/Package.swift
@@ -12,6 +12,10 @@ let package = Package(
       name: "GustoNetwork",
       targets: ["GustoNetwork"]
     ),
+    .library(
+      name: "ReviewEndpoints",
+      targets: ["ReviewEndpoints"]
+    )
   ],
   dependencies: [
     .package(name: "3rdParty", path: "../3rdParty"),
@@ -24,5 +28,9 @@ let package = Package(
       ],
       path: "Sources/Network"
     ),
+    .target(
+      name: "ReviewEndpoints",
+      path: "Sources/ReviewEndpoints"
+    )
   ]
 )

--- a/GustoNetwork/Sources/ReviewEndpoints/ReviewEndpoints.swift
+++ b/GustoNetwork/Sources/ReviewEndpoints/ReviewEndpoints.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+public enum ReviewEndpoints: Sendable {
+  case deleteReview(reviewId: Int64)
+  case fetch(reviewId: Int64)
+  case update(reviewId: Int64)
+  case create
+  case like(reviewId: Int64)
+  case search(keyword: String?, hasgTags: [Int64]?, cursorId: Int?)
+  case reviewsByOther(nickname: String, lastReviewId: Int64?, size: Int)
+  case randomFeed
+  case timelineView(lastReviewId: Int64?, size: Int)
+  case calview(lastReviewDate: String?, size: Int)
+  case instaview(lastReviewId: Int64?, size: Int)
+  case feedDetail(reviewId: Int64)
+  case unlike(reviewId: Int64)
+  
+  public var path: String {
+    return switch self {
+    case .deleteReview(let reviewId):
+      "/reviews/\(reviewId)"
+    case .fetch(let reviewId):
+      "/reviews/\(reviewId)"
+    case .update(let reviewId):
+      "/reviews/\(reviewId)"
+    case .create:
+      "/reviews"
+    case .like(let reviewId):
+      "/reviews/\(reviewId)/like"
+    case .search(let keyword, let hashTags, let cursorId):
+      {
+        let params: [String?] = [
+          keyword.map {"keyword=\($0)"},
+          hashTags.map{"hashTags=\($0.map{String($0)}.joined(separator: ","))"},
+          cursorId.map{"cursorId=\($0)"}
+        ]
+        return "/feeds/search?" + params.compactMap{$0}.joined(separator: "&")
+      }()
+    case .reviewsByOther(let nickname, let lastReviewId, let size):
+      "/reviews?nickName=\(nickname)\(lastReviewId != nil ? "&reviewId=\(lastReviewId!)" : "")&size=\(size)"
+    case .randomFeed:
+      "/feeds"
+    case .timelineView(let lastReviewId, let size):
+      "/reviews/timelineView?\(lastReviewId != nil ? "reviewId=\(lastReviewId!)&" : "")size=\(size)"
+    case .calview(let lastReviewDate, let size):
+      "/reviews/calView?\(lastReviewDate != nil ? "lastReviewDate=\(lastReviewDate!)&" : "")size=\(size)"
+    case .instaview(let lastReviewId, let size):
+      "/reviews/instaView?\(lastReviewId != nil ? "lastReviewId=\(lastReviewId!)&" : ""))"
+    case .feedDetail(let reviewId):
+      "/feeds/\(reviewId)"
+    case .unlike(let reviewId):
+      "reviews/\(reviewId)/unlike"
+    }
+  }
+}


### PR DESCRIPTION
<!--
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->

<br>

### 🥥 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

서버쪽 Review도메인 엔드포인트들 모아놨습니다.
노션하고 서버쪽 postman 참고해서 작성했습니다.

<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->
전에 얘기했던 방향이 이게 맞을까요?
libarary로 ReviewEndpoint만 타겟으로 만들어봤습니다.
endpoint를 사용할 수 있게 연산프로퍼티로 path를 만들어봤어요

DTO는 어떻게 하는 게 좋을까요?
DTO를 엔티티로 변환하는 것은 각 모듈에서 진행할 일이겠지만, DTO 자체는 endpoint처럼 명세의 일종이니까 여기에 포함시키는게 나을 지 고민됩니다.

<br>
